### PR TITLE
Update GitHub Actions workflow for Docker build

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout repository
-      - uses: actions/checkout@v4
+        uses: actions/checkout@v4
 
       # Runs a single command using the runners shell
       - name: Set up Docker Buildx
-      - uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v3
 
       # Runs a set of commands using the runners shell
       - name: Build Docker Image

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,0 +1,51 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - name: Checkout repository
+      - uses: actions/checkout@v4
+
+      # Runs a single command using the runners shell
+      - name: Set up Docker Buildx
+      - uses: docker/setup-buildx-action@v3
+
+      # Runs a set of commands using the runners shell
+      - name: Build Docker Image
+        run: |
+          docker build . --file Dockerfile --tag gamecollection-api:$(echo $GITHUB_SHA | cut -c1-7)
+
+      - name: Log in to Docker Hub
+        # This step is commented out for now. Uncomment and configure
+        # if you want to push the image to a registry like Docker Hub.
+        # uses: docker/login-action@v3
+        # with:
+        #   username: ${{ secrets.DOCKER_USERNAME }}
+        #   password: ${{ secrets.DOCKER_PASSWORD }}
+      
+      - name: Push Docker Image
+        # This step is also commented out. Uncomment to push the image.
+        # run: docker push gamecollection-api:$(echo $GITHUB_SHA | cut -c1-7)
+      
+      - name: List built images
+        run: docker images


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to automate building Docker images for the project. The workflow is triggered on pushes and pull requests to the `main` branch, and includes steps for checking out the repository, setting up Docker Buildx, building the Docker image, and listing built images. Steps for logging into Docker Hub and pushing images are included but currently commented out.

Continuous Integration workflow setup:

* Added `.github/workflows/blank.yml` to define a CI workflow that builds Docker images on push or pull request events to the `main` branch.
* Configured steps for repository checkout, Docker Buildx setup, Docker image building, and listing images.
* Included (but commented out) steps for Docker Hub login and image push, allowing easy future enablement for publishing images.