### PR TITLE
feat(auth/controllers): secure controllers, fix token expiration and register middleware

### DIFF
--- a/GameCollectionAPI/Controllers/GamesController.cs
+++ b/GameCollectionAPI/Controllers/GamesController.cs
@@ -7,6 +7,7 @@ namespace GameCollectionAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class GamesController : ControllerBase
     {
         private readonly IGameService _service;
@@ -22,6 +23,7 @@ namespace GameCollectionAPI.Controllers
         /// <returns>List of games.</returns>
         [HttpGet]
         [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         public async Task<IEnumerable<GameReadDto>> Get() => await _service.GetAllGamesAsync();
 
         /// <summary>
@@ -29,9 +31,10 @@ namespace GameCollectionAPI.Controllers
         /// </summary>
         /// <param name="id">Game ID.</param>
         /// <returns>The requested game.</returns>
-        [HttpGet("{id:int}")]
+        [HttpGet("{id:int}", Name = "GetGameById")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(int id)
         {
@@ -50,13 +53,15 @@ namespace GameCollectionAPI.Controllers
         [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> Post([FromBody] GameCreateDto createdGame)
         {
             if (createdGame == null) { return BadRequest(); }
 
             var game = await _service.CreateGameAsync(createdGame);
 
-            return CreatedAtAction(nameof(Get), new { id = game.Id }, game);
+            return CreatedAtRoute("GetGameById", new { id = game.Id }, game);
         }
 
         /// <summary>
@@ -66,8 +71,11 @@ namespace GameCollectionAPI.Controllers
         /// <param name="updatedGame">Updated game object.</param>
         /// <returns>No content.</returns>
         [HttpPut("{id:int}")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Put(int id, [FromBody] GameCreateDto updatedGame)
         {
@@ -83,8 +91,11 @@ namespace GameCollectionAPI.Controllers
         /// <param name="id">Game ID.</param>
         /// <returns>No content.</returns>
         [HttpDelete("{id:int}")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Delete(int id)
         {

--- a/GameCollectionAPI/Controllers/UsersController.cs
+++ b/GameCollectionAPI/Controllers/UsersController.cs
@@ -1,12 +1,15 @@
+using System.Security.Claims;
 using GameCollectionAPI.DTOs.Users;
 using GameCollectionAPI.Exceptions;
 using GameCollectionAPI.Services;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 
 namespace GameCollectionAPI.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class UsersController : ControllerBase
     {
         private readonly IUserService _service;
@@ -27,6 +30,11 @@ namespace GameCollectionAPI.Controllers
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Get(int id)
         {
+            if (!IsOwnerOrAdmin(id))
+            {
+                return Forbid();
+            }
+
             if (id == 0) { return BadRequest(); }
 
             var user = await _service.GetUserByIdAsync(id);
@@ -40,6 +48,7 @@ namespace GameCollectionAPI.Controllers
         /// <param name="createdUser">The user creation DTO.</param>
         /// <returns>The created user.</returns>
         [HttpPost]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
@@ -71,6 +80,11 @@ namespace GameCollectionAPI.Controllers
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> UpdateUsername(int id, [FromBody] UpdateUsernameDto updateUsernameDto)
         {
+            if (!IsOwnerOrAdmin(id))
+            {
+                return Forbid();
+            }
+
             if (id == 0 || updateUsernameDto == null) { return BadRequest(); }
 
             try
@@ -90,6 +104,7 @@ namespace GameCollectionAPI.Controllers
         /// <param name="id">User's ID.</param>
         /// <returns>No content if deleted; NotFound if user does not exist.</returns>
         [HttpDelete("{id:int}")]
+        [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
@@ -99,6 +114,16 @@ namespace GameCollectionAPI.Controllers
 
             bool successful = await _service.DeleteUserAsync(id);
             return successful ? NoContent() : NotFound();
+        }
+
+        bool IsOwnerOrAdmin(int id)
+        {
+            var currentUserIdClaim = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+
+            bool isOwner = currentUserIdClaim == id.ToString();
+            bool isAdmin = User.IsInRole("Admin");
+
+            return isOwner || isAdmin;
         }
     }
 }

--- a/GameCollectionAPI/Controllers/UsersController.cs
+++ b/GameCollectionAPI/Controllers/UsersController.cs
@@ -27,7 +27,10 @@ namespace GameCollectionAPI.Controllers
         [HttpGet("{id:int}", Name = "GetUserById")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         public async Task<IActionResult> Get(int id)
         {
             if (!IsOwnerOrAdmin(id))
@@ -51,6 +54,8 @@ namespace GameCollectionAPI.Controllers
         [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status201Created)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> Create([FromBody] UserCreateDto createdUser)
         {
@@ -76,7 +81,9 @@ namespace GameCollectionAPI.Controllers
         [HttpPut("{id:int}")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status409Conflict)]
         public async Task<IActionResult> UpdateUsername(int id, [FromBody] UpdateUsernameDto updateUsernameDto)
         {
@@ -107,6 +114,8 @@ namespace GameCollectionAPI.Controllers
         [Authorize(Roles = "Admin")]
         [ProducesResponseType(StatusCodes.Status204NoContent)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status403Forbidden)]
         [ProducesResponseType(StatusCodes.Status404NotFound)]
         public async Task<IActionResult> Delete(int id)
         {

--- a/GameCollectionAPI/Program.cs
+++ b/GameCollectionAPI/Program.cs
@@ -65,6 +65,9 @@ else
     app.UseHttpsRedirection();
 }
 
+app.UseAuthentication();
+app.UseAuthorization();
+
 app.MapControllers();
 
 app.Run();

--- a/GameCollectionAPI/Services/AuthService.cs
+++ b/GameCollectionAPI/Services/AuthService.cs
@@ -99,7 +99,7 @@ public class AuthService : IAuthService
         var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
 
         // Expiration
-        var expires = DateTime.Now.AddHours(1);
+        var expires = DateTime.UtcNow.AddHours(1);
 
         // Create token
         var token = new JwtSecurityToken(


### PR DESCRIPTION
## Description
This pull request implements authentication and authorization across the API controllers, secures game and user actions with role-based and ownership checks, documents response status codes, registers auth middleware, and fixes token expiration calculation to use UTC time.

### Key Changes

#### 1. Controller Security & API Documentation
* **GamesController**:
  * Secured the entire controller with `[Authorize]`.
  * Restricted creation, updates, and deletion to users with the `Admin` role.
  * Added Swagger/documentation response attributes for `401 Unauthorized` and `403 Forbidden` statuses.
  * Corrected redirection response inside `Post` using `CreatedAtRoute`.
* **UsersController**:
  * Secured the entire controller with `[Authorize]`.
  * Implemented `IsOwnerOrAdmin(id)` validation helper to ensure users can only retrieve or update their own user record, unless they are an `Admin`.
  * Restricted user creation and deletion to the `Admin` role.
  * Documented `401 Unauthorized` and `403 Forbidden` response types.

#### 2. Middleware & Authentication Services
* **Program.cs**: Registered `app.UseAuthentication()` and `app.UseAuthorization()` middleware in the application pipeline.
* **AuthService**: Changed JWT token expiration calculation to use `DateTime.UtcNow` instead of local system time to prevent timezone discrepancies.
